### PR TITLE
fixing menu's golden highlight css (#106)

### DIFF
--- a/css/w3develops.css
+++ b/css/w3develops.css
@@ -16,8 +16,8 @@ iframe#googleForm {
     width:100%;
 }
 
-.dropdown-list.dropdown-list-item:hover,
-.dropdown-list.dropdown-list-item:focus,
-.dropdown-listn.dropdow-list-item:active {
-    color: #fed136;
+nav#mainNav .dropdown-item.dropdown-list-item:hover,
+nav#mainNav .dropdown-item.dropdown-list-item:focus,
+nav#mainNav .dropdown-item.dropdown-list-item:active {
+    background-color: #fed136;
 }

--- a/navigation.html
+++ b/navigation.html
@@ -12,24 +12,24 @@
         <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
           Community
         </a>
-        <div class="dropdown-menu dropdow-list text-center" aria-labelledby="navbarDropdown">
+        <div class="dropdown-menu dropdown-list text-center" aria-labelledby="navbarDropdown">
        <!-- <a class="dropdown-item" href="#" target="_blank" rel="noopener noreferrer">Local Devs</a>-->
         <!--<a class="dropdown-item" href="#" target="_blank" rel="noopener noreferrer">Meetups</a>-->
-        <a class="dropdown-item dropdow-list-item" href="https://discord.gg/ckQ52gA" target="_blank" rel="noopener noreferrer">Discord Chat!!!</a>
+        <a class="dropdown-item dropdown-list-item" href="https://discord.gg/ckQ52gA" target="_blank" rel="noopener noreferrer">Discord Chat!!!</a>
         <!--<a class="dropdown-item" href="#" target="_blank" rel="noopener noreferrer">Forum</a>-->
-          <a class="dropdown-item dropdow-list-item" href="https://www.facebook.com/groups/w3develops/" target="_blank"
+          <a class="dropdown-item dropdown-list-item" href="https://www.facebook.com/groups/w3develops/" target="_blank"
              rel="noopener noreferrer">Facebook Group</a>
-        <a class="dropdown-item dropdow-list-item" href="https://www.youtube.com/channel/UCCf9xpbgNEO0G1NdqhGvtjA" target="_blank"
+        <a class="dropdown-item dropdown-list-item" href="https://www.youtube.com/channel/UCCf9xpbgNEO0G1NdqhGvtjA" target="_blank"
            rel="noopener noreferrer">YouTube
         </a>
-          <a class="dropdown-item dropdow-list-item" href="https://github.com/w3develops" target="_blank" rel="noopener noreferrer">Github</a>
-        <a class="dropdown-item dropdow-list-item" href="https://www.linkedin.com/company/w3develops" target="_blank" rel="noopener noreferrer">
+          <a class="dropdown-item dropdown-list-item" href="https://github.com/w3develops" target="_blank" rel="noopener noreferrer">Github</a>
+        <a class="dropdown-item dropdown-list-item" href="https://www.linkedin.com/company/w3develops" target="_blank" rel="noopener noreferrer">
             LinkedIn</a>
-                  <a class="dropdown-item dropdow-list-item" href="https://soundcloud.com/w3develops" target="_blank" rel="noopener noreferrer">
+                  <a class="dropdown-item dropdown-list-item" href="https://soundcloud.com/w3develops" target="_blank" rel="noopener noreferrer">
                       Soundcloud</a>
-        <a class="dropdown-item dropdow-list-item" href="https://medium.com/w3develops" target="_blank" rel="noopener noreferrer">Medium</a>
-        <a class="dropdown-item dropdow-list-item" href="https://twitter.com/w3develops" target="_blank" rel="noopener noreferrer">Twitter</a>
-                  <a class="dropdown-item dropdow-list-item" href="https://www.instagram.com/w3develops/" target="_blank" rel="noopener noreferrer">
+        <a class="dropdown-item dropdown-list-item" href="https://medium.com/w3develops" target="_blank" rel="noopener noreferrer">Medium</a>
+        <a class="dropdown-item dropdown-list-item" href="https://twitter.com/w3develops" target="_blank" rel="noopener noreferrer">Twitter</a>
+                  <a class="dropdown-item dropdown-list-item" href="https://www.instagram.com/w3develops/" target="_blank" rel="noopener noreferrer">
                       Instagram</a>
 
           <!--
@@ -45,15 +45,15 @@
         </a>
         <div class="dropdown-menu text-center" aria-labelledby="navbarDropdown">
 
-        <a class="dropdown-item" href="https://discord.gg/ckQ52gA" target="_blank" rel="noopener noreferrer">W3Develops Cohorts</a>
+        <a class="dropdown-item dropdown-list-item" href="https://discord.gg/ckQ52gA" target="_blank" rel="noopener noreferrer">W3Develops Cohorts</a>
 
          <!-- Where people from past cohorts can start their own cohort or projectand other can join: -->
-     <!--   <a class="dropdown-item" href="#">Code Incubator</a>-->
+     <!--   <a class="dropdown-item dropdown-list-item" href="#">Code Incubator</a>-->
       <!--challenges lik hactober and hundred days of code and decembers hacktober fest called 24 pulls as well as 365 days lof code and 30 days 30 sites-->
-         <!-- <a class="dropdown-item" href="#">Challenges</a>-->
-        <!--<a class="dropdown-item" href="#">Team Guides</a>-->
-        <!--<a class="dropdown-item" href="#">Learn</a>-->
-        <!--<a class="dropdown-item" href="#">Scoreboards</a>-->
+         <!-- <a class="dropdown-item dropdown-list-item" href="#">Challenges</a>-->
+        <!--<a class="dropdown-item dropdown-list-item" href="#">Team Guides</a>-->
+        <!--<a class="dropdown-item dropdown-list-item" href="#">Learn</a>-->
+        <!--<a class="dropdown-item dropdown-list-item" href="#">Scoreboards</a>-->
 <!--add a contributor page in the about page-->
           <!--<a class="dropdown-item" href="#">About</a>-->
 


### PR DESCRIPTION
This should address issue #106 
fixed typos in navigation and w3develops.css (other contributors have pointed these typos out)
added dropdown-list-item class to W3Develops Cohorts under Maps so css would work on this link as well.
tested in Edge42, Chrome 70, and Firefox 63.0
make sure you clear your cache before deciding it doesn't work!
(If you have chrome you can right click on something and inspect element, click sources, w3develops.css, verify the css selector mentions nav#mainNav if it doesn't then it's a cached version of the site!)
This pull is based off of the following contributors and contributions:
#125 the changes highlighted in this PR are made here.
@JonDevOps 
@ocReaper #108 
@nSedrickm #128 
@jaebirds #127 
@myrosvas #106 
Thank you all for your contributions!